### PR TITLE
[Feat] 관리자 메뉴 관리 및 비 로그인 담기 시 로그인 창으로 이동 

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import MenuManagement from "../../components/features/admin/MenuManagement";
+
+const AdminPage: React.FC = () => {
+  return (
+    <div>
+      <MenuManagement />
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,9 +34,9 @@ export default function RootLayout({
           <CartProvider>
             <AddressProvider>
               <Header />
-              <main className="flex-1 w-full pb-14">
-                <div className="max-w-7xl mx-auto px-4">{children}</div>
-              </main>
+                <main className="flex-1 w-full pb-14">
+                  <div className="max-w-7xl mx-auto px-4">{children}</div>
+                </main>
               <Footer />
             </AddressProvider>
           </CartProvider>

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -4,7 +4,7 @@ import { ElementType } from "react";
 
 interface ButtonProps {
   icon?: ElementType;
-  text: string;
+  text?: string;
   bgColor?: string;
   hoverColor?: string;
   fontColor?: string;
@@ -46,8 +46,8 @@ const Button = ({
       onClick={onClick}
       disabled={disabled}
     >
-      {Icon && <Icon className="w-5 h-5 mr-2" />}
-      <span className="font-medium">{text}</span>
+      {Icon && <Icon className={`w-5 h-5 ${text ? "mr-2" : ""}`} />}
+      {text && <span className="font-medium">{text}</span>}
     </button>
   );
 };

--- a/src/components/common/PencilIcon.tsx
+++ b/src/components/common/PencilIcon.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const PencilIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    {...props}
+  >
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+  </svg>
+);
+
+export default PencilIcon;

--- a/src/components/common/ToggleSwitch.tsx
+++ b/src/components/common/ToggleSwitch.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface ToggleSwitchProps {
+  isOn: boolean;
+  handleToggle: () => void;
+  onColor?: string;
+  offColor?: string;
+}
+
+const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
+  isOn,
+  handleToggle,
+  onColor = 'bg-green-500',
+  offColor = 'bg-red-500',
+}) => {
+  return (
+    <div
+      className={`relative inline-flex items-center h-6 rounded-full w-11 cursor-pointer transition-colors duration-200 ease-in-out ${isOn ? onColor : offColor}`}
+      onClick={handleToggle}
+    >
+      <span
+        className={`transform transition-transform duration-200 ease-in-out inline-block w-5 h-5 bg-white rounded-full shadow-md ${isOn ? 'translate-x-5' : 'translate-x-0.5'}`}
+      />
+    </div>
+  );
+};
+
+export default ToggleSwitch;

--- a/src/components/common/TrashIcon.tsx
+++ b/src/components/common/TrashIcon.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const TrashIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    {...props}
+  >
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+  </svg>
+);
+
+export default TrashIcon;

--- a/src/components/features/admin/AddEditMenuModal.tsx
+++ b/src/components/features/admin/AddEditMenuModal.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Modal } from "@/src/components/common/Modal";
+import { Input } from "@/src/components/common/Input";
+import Button from "@/src/components/common/Button";
+import { Product } from "@/src/components/features/home/types";
+
+interface AddEditMenuModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (product: Product) => void;
+  editingProduct?: Product;
+}
+
+const AddEditMenuModal: React.FC<AddEditMenuModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  editingProduct,
+}) => {
+  const [name, setName] = useState("");
+  const [price, setPrice] = useState<number | null>(null);
+  const [category, setCategory] = useState("");
+  const [description, setDescription] = useState("");
+  const [image, setImage] = useState<string | null>(null); // To store base64 string
+  const [imagePreview, setImagePreview] = useState<string | null>(null); // To display image preview
+
+  useEffect(() => {
+    if (editingProduct) {
+      setName(editingProduct.name);
+      setPrice(editingProduct.price);
+      setCategory(editingProduct.category);
+      setDescription(editingProduct.description);
+      setImage(editingProduct.image); // Assuming editingProduct.image is a URL or base64
+      setImagePreview(editingProduct.image); // Display existing image
+    } else {
+      setName("");
+      setPrice(null);
+      setCategory("");
+      setDescription("");
+      setImage(null);
+      setImagePreview(null);
+    }
+  }, [editingProduct]);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImage(reader.result as string);
+        setImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    } else {
+      setImage(null);
+      setImagePreview(null);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newProduct: Product = {
+      id: editingProduct ? editingProduct.id : Date.now(), // Simple ID generation
+      name,
+      price: price !== null ? price : 0,
+      category,
+      description,
+      image: image || "", // Ensure image is a string, even if null
+      isSoldOut: editingProduct ? editingProduct.isSoldOut : false,
+    };
+    onSave(newProduct);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Modal onClose={onClose}>
+      <div className="bg-white rounded-2xl shadow-2xl p-10 max-w-lg w-full mx-auto my-8 border border-gray-100">
+        <h2 className="text-4xl font-extrabold mb-10 text-gray-900 text-center tracking-tight">
+          {editingProduct ? "메뉴 수정" : "메뉴 추가"}
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-7">
+          <div>
+            <label htmlFor="name" className="block text-gray-700 text-sm font-semibold mb-2">
+              메뉴 이름
+            </label>
+            <Input
+              id="name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full px-4 py-2 border-b-2 border-gray-200 focus:border-blue-500 outline-none text-lg"
+            />
+          </div>
+          <div>
+            <label htmlFor="price" className="block text-gray-700 text-sm font-semibold mb-2">
+              가격
+            </label>
+            <Input
+              id="price"
+              type="number"
+              value={price !== null ? price.toString() : ""}
+              onChange={(e) => setPrice(e.target.value === '' ? null : Number(e.target.value))}
+              required
+              className="w-full px-4 py-2 border-b-2 border-gray-200 focus:border-blue-500 outline-none text-lg"
+            />
+          </div>
+          <div>
+            <label htmlFor="category" className="block text-gray-700 text-sm font-semibold mb-2 whitespace-nowrap">
+              카테고리
+            </label>
+            <Input
+              id="category"
+              type="text"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              required
+              className="w-full px-4 py-2 border-b-2 border-gray-200 focus:border-blue-500 outline-none text-lg"
+            />
+          </div>
+          <div>
+            <label htmlFor="description" className="block text-gray-700 text-sm font-semibold mb-2">
+              설명
+            </label>
+            <Input
+              id="description"
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              required
+              className="w-full px-4 py-2 border-b-2 border-gray-200 focus:border-blue-500 outline-none text-lg"
+            />
+          </div>
+          <div>
+            <label htmlFor="image" className="block text-gray-700 text-sm font-semibold mb-2">
+              이미지 파일
+            </label>
+            <input
+              id="image"
+              type="file"
+              accept="image/*"
+              onChange={handleImageChange}
+              className="w-full text-gray-700 border border-gray-200 rounded-lg cursor-pointer bg-gray-50 focus:outline-none file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+            />
+            {imagePreview && (
+              <div className="mt-6 flex justify-center">
+                <img src={imagePreview} alt="Image Preview" className="max-w-full h-48 object-cover rounded-lg shadow-md border border-gray-200" />
+              </div>
+            )}
+          </div>
+          <div className="flex justify-end space-x-4 pt-6">
+            <Button
+              onClick={onClose}
+              text="취소"
+              bgColor="bg-gray-100"
+              hoverColor="hover:bg-gray-200"
+              fontColor="text-gray-700"
+              className="px-6 py-3 rounded-lg font-semibold shadow-sm hover:shadow-md"
+            />
+            <Button
+              text="저장"
+              bgColor="bg-blue-600"
+              hoverColor="hover:bg-blue-700"
+              fontColor="text-white"
+              className="px-6 py-3 rounded-lg font-semibold shadow-md hover:shadow-lg"
+            />
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+};
+
+export default AddEditMenuModal;

--- a/src/components/features/admin/AddEditMenuModal.tsx
+++ b/src/components/features/admin/AddEditMenuModal.tsx
@@ -20,7 +20,7 @@ const AddEditMenuModal: React.FC<AddEditMenuModalProps> = ({
   editingProduct,
 }) => {
   const [name, setName] = useState("");
-  const [price, setPrice] = useState<number | null>(null);
+  const [price, setPrice] = useState<number>(0);
   const [category, setCategory] = useState("");
   const [description, setDescription] = useState("");
   const [image, setImage] = useState<string | null>(null); // To store base64 string
@@ -36,7 +36,7 @@ const AddEditMenuModal: React.FC<AddEditMenuModalProps> = ({
       setImagePreview(editingProduct.image); // Display existing image
     } else {
       setName("");
-      setPrice(null);
+      setPrice(0);
       setCategory("");
       setDescription("");
       setImage(null);
@@ -64,7 +64,7 @@ const AddEditMenuModal: React.FC<AddEditMenuModalProps> = ({
     const newProduct: Product = {
       id: editingProduct ? editingProduct.id : Date.now(), // Simple ID generation
       name,
-      price: price !== null ? price : 0,
+      price,
       category,
       description,
       image: image || "", // Ensure image is a string, even if null
@@ -102,8 +102,8 @@ const AddEditMenuModal: React.FC<AddEditMenuModalProps> = ({
             <Input
               id="price"
               type="number"
-              value={price !== null ? price.toString() : ""}
-              onChange={(e) => setPrice(e.target.value === '' ? null : Number(e.target.value))}
+              value={price.toString()}
+              onChange={(e) => setPrice(Number(e.target.value))}
               required
               className="w-full px-4 py-2 border-b-2 border-gray-200 focus:border-blue-500 outline-none text-lg"
             />

--- a/src/components/features/admin/MenuManagement.tsx
+++ b/src/components/features/admin/MenuManagement.tsx
@@ -15,11 +15,21 @@ const MenuManagement: React.FC = () => {
   const [changedProducts, setChangedProducts] = useState<Set<number>>(new Set());
   const [showAddEditModal, setShowAddEditModal] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | undefined>(undefined);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('All');
+
+  const categories = ['All', ...Array.from(new Set(PRODUCTS.map(product => product.category)))];
 
   useEffect(() => {
     setProducts(PRODUCTS);
     setOriginalProducts(PRODUCTS);
   }, []);
+
+  const filteredProducts = products.filter(product => {
+    const matchesSearchTerm = product.name.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesCategory = selectedCategory === 'All' || product.category === selectedCategory;
+    return matchesSearchTerm && matchesCategory;
+  });
 
   const handleToggleSoldOut = (id: number) => {
     setProducts((prevProducts) =>
@@ -82,24 +92,44 @@ const MenuManagement: React.FC = () => {
     <div className="container mx-auto p-6 min-h-screen">
       <h1 className="text-3xl font-extrabold text-gray-800 mb-8 text-center">메뉴 관리</h1>
 
-      <div className="flex justify-end mb-6">
-        <Button
-          onClick={handleSave}
-          disabled={!hasChanges}
-          className="px-6 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-75 transition duration-300 ease-in-out disabled:bg-gray-400 disabled:cursor-not-allowed"
-          text="변경사항 저장"
-          fontColor="text-white"
-          bgColor="bg-indigo-600"
-          hoverColor="hover:bg-indigo-700"
-        />
-        <Button
-          onClick={handleAddMenu}
-          className="ml-4 px-6 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-opacity-75 transition duration-300 ease-in-out"
-          text="메뉴 추가"
-          fontColor="text-white"
-          bgColor="bg-green-500"
-          hoverColor="hover:bg-green-600"
-        />
+      <div className="flex justify-between items-center mb-6">
+        <div className="flex space-x-4">
+          <input
+            type="text"
+            placeholder="메뉴 검색..."
+            className="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+          <select
+            className="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
+          >
+            {categories.map(category => (
+              <option key={category} value={category}>{category}</option>
+            ))}
+          </select>
+        </div>
+        <div className="flex">
+          <Button
+            onClick={handleSave}
+            disabled={!hasChanges}
+            className="px-6 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-75 transition duration-300 ease-in-out disabled:bg-gray-400 disabled:cursor-not-allowed"
+            text="변경사항 저장"
+            fontColor="text-white"
+            bgColor="bg-indigo-600"
+            hoverColor="hover:bg-indigo-700"
+          />
+          <Button
+            onClick={handleAddMenu}
+            className="ml-4 px-6 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-opacity-75 transition duration-300 ease-in-out"
+            text="메뉴 추가"
+            fontColor="text-white"
+            bgColor="bg-green-500"
+            hoverColor="hover:bg-green-600"
+          />
+        </div>
       </div>
 
       <div className="overflow-x-auto bg-white shadow-lg rounded-lg">
@@ -117,7 +147,7 @@ const MenuManagement: React.FC = () => {
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {products.map((product) => (
+            {filteredProducts.map((product) => (
               <tr key={product.id} className={`hover:bg-gray-50 ${changedProducts.has(product.id) ? "bg-yellow-50" : ""}`}>
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{product.id}</td>
                 <td className="px-6 py-4 whitespace-nowrap">

--- a/src/components/features/admin/MenuManagement.tsx
+++ b/src/components/features/admin/MenuManagement.tsx
@@ -7,10 +7,14 @@ import PencilIcon from "@/src/components/common/PencilIcon";
 import ToggleSwitch from "@/src/components/common/ToggleSwitch";
 import {PRODUCTS} from "@/src/components/features/home/data/products";
 import {Product} from "@/src/components/features/home/types";
+import AddEditMenuModal from "@/src/components/features/admin/AddEditMenuModal";
+
 const MenuManagement: React.FC = () => {
   const [products, setProducts] = useState<Product[]>([]);
   const [originalProducts, setOriginalProducts] = useState<Product[]>([]);
   const [changedProducts, setChangedProducts] = useState<Set<number>>(new Set());
+  const [showAddEditModal, setShowAddEditModal] = useState(false);
+  const [editingProduct, setEditingProduct] = useState<Product | undefined>(undefined);
 
   useEffect(() => {
     setProducts(PRODUCTS);
@@ -34,7 +38,11 @@ const MenuManagement: React.FC = () => {
   };
 
   const handleEditProduct = (id: number) => {
-    alert(`제품 ID ${id} 수정`);
+    const productToEdit = products.find(p => p.id === id);
+    if (productToEdit) {
+      setEditingProduct(productToEdit);
+      setShowAddEditModal(true);
+    }
   };
 
   const handleSave = () => {
@@ -47,8 +55,25 @@ const MenuManagement: React.FC = () => {
   };
 
   const handleAddMenu = () => {
-    alert("메뉴 추가 기능 구현 예정");
-    // 여기에 메뉴 추가 로직을 구현하세요.
+    setEditingProduct(undefined);
+    setShowAddEditModal(true);
+  };
+
+  const handleSaveProduct = (product: Product) => {
+    setProducts((prevProducts) => {
+      const existingProductIndex = prevProducts.findIndex(p => p.id === product.id);
+      if (existingProductIndex > -1) {
+        // Update existing product
+        return prevProducts.map((p, index) =>
+          index === existingProductIndex ? product : p
+        );
+      } else {
+        // Add new product
+        return [...prevProducts, product];
+      }
+    });
+    setChangedProducts((prev) => new Set(prev.add(product.id)));
+    setShowAddEditModal(false);
   };
 
   const hasChanges = changedProducts.size > 0;
@@ -85,7 +110,7 @@ const MenuManagement: React.FC = () => {
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이미지</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이름</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">가격</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">카테고리</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-25">카테고리</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">설명</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">품절 상태</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">액션</th>
@@ -106,18 +131,18 @@ const MenuManagement: React.FC = () => {
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{product.price.toLocaleString()}원</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{product.category}</td>
                 <td className="px-6 py-4 text-sm text-gray-500 overflow-hidden text-ellipsis">{product.description}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm">
+                <td className="px-6 py-4 whitespace-nowrap text-sm items-center">
                   <ToggleSwitch
                     isOn={!product.isSoldOut}
                     handleToggle={() => handleToggleSoldOut(product.id)}
                     onColor="bg-green-500"
                     offColor="bg-red-500"
                   />
-                  <span className="ml-2 text-gray-700 font-medium">
+                  <span className="ml-2 text-gray-700 font-medium align-middle">
                     {product.isSoldOut ? "품절" : "판매중"}
                   </span>
                 </td>
-                <td className="px-6 py-7 flex justify-between items-center">
+                <td className="px-6 py-4 flex justify-between items-center">
                   <Button
                     onClick={() => handleEditProduct(product.id)}
                     icon={PencilIcon}
@@ -138,6 +163,15 @@ const MenuManagement: React.FC = () => {
           </tbody>
         </table>
       </div>
+
+      {showAddEditModal && (
+        <AddEditMenuModal
+          isOpen={showAddEditModal}
+          onClose={() => setShowAddEditModal(false)}
+          onSave={handleSaveProduct}
+          editingProduct={editingProduct}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/features/admin/MenuManagement.tsx
+++ b/src/components/features/admin/MenuManagement.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import Button from "@/src/components/common/Button";
+import TrashIcon from "@/src/components/common/TrashIcon";
+import PencilIcon from "@/src/components/common/PencilIcon";
+import ToggleSwitch from "@/src/components/common/ToggleSwitch";
+import {PRODUCTS} from "@/src/components/features/home/data/products";
+import {Product} from "@/src/components/features/home/types";
+const MenuManagement: React.FC = () => {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [originalProducts, setOriginalProducts] = useState<Product[]>([]);
+  const [changedProducts, setChangedProducts] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    setProducts(PRODUCTS);
+    setOriginalProducts(PRODUCTS);
+  }, []);
+
+  const handleToggleSoldOut = (id: number) => {
+    setProducts((prevProducts) =>
+      prevProducts.map((product) =>
+        product.id === id
+          ? { ...product, isSoldOut: !product.isSoldOut }
+          : product
+      )
+    );
+    setChangedProducts((prev) => new Set(prev.add(id)));
+  };
+
+  const handleDeleteProduct = (id: number) => {
+    setProducts((prevProducts) => prevProducts.filter((product) => product.id !== id));
+    setChangedProducts((prev) => new Set(prev.add(id))); // Mark as changed for deletion
+  };
+
+  const handleEditProduct = (id: number) => {
+    alert(`제품 ID ${id} 수정`);
+  };
+
+  const handleSave = () => {
+    // const updatedProducts = products.filter(product => !originalProducts.some(op => op.id === product.id && op.isSoldOut === product.isSoldOut));
+    // const deletedProductIds = originalProducts.filter(op => !products.some(p => p.id === op.id)).map(p => p.id);
+
+    setOriginalProducts(products);
+    setChangedProducts(new Set());
+    alert("변경사항이 저장되었습니다.");
+  };
+
+  const handleAddMenu = () => {
+    alert("메뉴 추가 기능 구현 예정");
+    // 여기에 메뉴 추가 로직을 구현하세요.
+  };
+
+  const hasChanges = changedProducts.size > 0;
+
+  return (
+    <div className="container mx-auto p-6 min-h-screen">
+      <h1 className="text-3xl font-extrabold text-gray-800 mb-8 text-center">메뉴 관리</h1>
+
+      <div className="flex justify-end mb-6">
+        <Button
+          onClick={handleSave}
+          disabled={!hasChanges}
+          className="px-6 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-75 transition duration-300 ease-in-out disabled:bg-gray-400 disabled:cursor-not-allowed"
+          text="변경사항 저장"
+          fontColor="text-white"
+          bgColor="bg-indigo-600"
+          hoverColor="hover:bg-indigo-700"
+        />
+        <Button
+          onClick={handleAddMenu}
+          className="ml-4 px-6 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-opacity-75 transition duration-300 ease-in-out"
+          text="메뉴 추가"
+          fontColor="text-white"
+          bgColor="bg-green-500"
+          hoverColor="hover:bg-green-600"
+        />
+      </div>
+
+      <div className="overflow-x-auto bg-white shadow-lg rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이미지</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이름</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">가격</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">카테고리</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">설명</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">품절 상태</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">액션</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {products.map((product) => (
+              <tr key={product.id} className={`hover:bg-gray-50 ${changedProducts.has(product.id) ? "bg-yellow-50" : ""}`}>
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{product.id}</td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <img
+                    src={product.image}
+                    alt={product.name}
+                    className="w-16 h-16 object-cover rounded-md shadow-sm"
+                  />
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{product.name}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{product.price.toLocaleString()}원</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{product.category}</td>
+                <td className="px-6 py-4 text-sm text-gray-500 overflow-hidden text-ellipsis">{product.description}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm">
+                  <ToggleSwitch
+                    isOn={!product.isSoldOut}
+                    handleToggle={() => handleToggleSoldOut(product.id)}
+                    onColor="bg-green-500"
+                    offColor="bg-red-500"
+                  />
+                  <span className="ml-2 text-gray-700 font-medium">
+                    {product.isSoldOut ? "품절" : "판매중"}
+                  </span>
+                </td>
+                <td className="px-6 py-7 flex justify-between items-center">
+                  <Button
+                    onClick={() => handleEditProduct(product.id)}
+                    icon={PencilIcon}
+                    fontColor="text-white"
+                    bgColor="bg-blue-500"
+                    hoverColor="hover:bg-blue-600"
+                  />
+                  <Button
+                    onClick={() => handleDeleteProduct(product.id)}
+                    icon={TrashIcon}
+                    fontColor="text-white"
+                    bgColor="bg-red-500"
+                    hoverColor="hover:bg-red-600"
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default MenuManagement;

--- a/src/components/features/admin/MenuManagement.tsx
+++ b/src/components/features/admin/MenuManagement.tsx
@@ -56,9 +56,6 @@ const MenuManagement: React.FC = () => {
   };
 
   const handleSave = () => {
-    // const updatedProducts = products.filter(product => !originalProducts.some(op => op.id === product.id && op.isSoldOut === product.isSoldOut));
-    // const deletedProductIds = originalProducts.filter(op => !products.some(p => p.id === op.id)).map(p => p.id);
-
     setOriginalProducts(products);
     setChangedProducts(new Set());
     alert("변경사항이 저장되었습니다.");
@@ -73,12 +70,10 @@ const MenuManagement: React.FC = () => {
     setProducts((prevProducts) => {
       const existingProductIndex = prevProducts.findIndex(p => p.id === product.id);
       if (existingProductIndex > -1) {
-        // Update existing product
         return prevProducts.map((p, index) =>
           index === existingProductIndex ? product : p
         );
       } else {
-        // Add new product
         return [...prevProducts, product];
       }
     });
@@ -89,20 +84,23 @@ const MenuManagement: React.FC = () => {
   const hasChanges = changedProducts.size > 0;
 
   return (
-    <div className="container mx-auto p-6 min-h-screen">
-      <h1 className="text-3xl font-extrabold text-gray-800 mb-8 text-center">메뉴 관리</h1>
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8 min-h-screen">
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold text-gray-800">메뉴 관리</h1>
+        <p className="text-gray-500 mt-2">메뉴를 추가, 수정, 삭제하고 품절 상태를 관리하세요.</p>
+      </div>
 
-      <div className="flex justify-between items-center mb-6">
-        <div className="flex space-x-4">
+      <div className="mb-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+        <div className="flex flex-col sm:flex-row items-center gap-4 w-full sm:w-auto">
           <input
             type="text"
             placeholder="메뉴 검색..."
-            className="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 w-full sm:w-64"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
           <select
-            className="p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 w-full sm:w-auto"
             value={selectedCategory}
             onChange={(e) => setSelectedCategory(e.target.value)}
           >
@@ -111,19 +109,19 @@ const MenuManagement: React.FC = () => {
             ))}
           </select>
         </div>
-        <div className="flex">
+        <div className="flex gap-4 w-full sm:w-auto">
           <Button
             onClick={handleSave}
             disabled={!hasChanges}
-            className="px-6 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-75 transition duration-300 ease-in-out disabled:bg-gray-400 disabled:cursor-not-allowed"
+            className="w-full sm:w-auto"
             text="변경사항 저장"
             fontColor="text-white"
-            bgColor="bg-indigo-600"
-            hoverColor="hover:bg-indigo-700"
+            bgColor="bg-blue-600"
+            hoverColor="hover:bg-blue-700"
           />
           <Button
             onClick={handleAddMenu}
-            className="ml-4 px-6 py-3 font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-opacity-75 transition duration-300 ease-in-out"
+            className="w-full sm:w-auto"
             text="메뉴 추가"
             fontColor="text-white"
             bgColor="bg-green-500"
@@ -132,61 +130,63 @@ const MenuManagement: React.FC = () => {
         </div>
       </div>
 
-      <div className="overflow-x-auto bg-white shadow-lg rounded-lg">
+      <div className="overflow-x-auto bg-white shadow-md rounded-lg">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-100">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이미지</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">이름</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">가격</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-25">카테고리</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">설명</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">품절 상태</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">액션</th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">메뉴</th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">가격</th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">카테고리</th>
+              <th className="px-6 py-3 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">상태</th>
+              <th className="px-6 py-3 text-center text-xs font-semibold text-gray-600 uppercase tracking-wider">관리</th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {filteredProducts.map((product) => (
-              <tr key={product.id} className={`hover:bg-gray-50 ${changedProducts.has(product.id) ? "bg-yellow-50" : ""}`}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{product.id}</td>
+              <tr key={product.id} className={`transition-colors duration-200 ${changedProducts.has(product.id) ? "bg-yellow-50" : "hover:bg-gray-50"}`}>
                 <td className="px-6 py-4 whitespace-nowrap">
-                  <img
-                    src={product.image}
-                    alt={product.name}
-                    className="w-16 h-16 object-cover rounded-md shadow-sm"
-                  />
+                  <div className="flex items-center">
+                    <div className="flex-shrink-0 h-12 w-12">
+                      <img className="h-12 w-12 rounded-md object-cover" src={product.image} alt={product.name} />
+                    </div>
+                    <div className="ml-4">
+                      <div className="text-sm font-medium text-gray-900">{product.name}</div>
+                      <div className="text-sm text-gray-500">{product.description}</div>
+                    </div>
+                  </div>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{product.name}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{product.price.toLocaleString()}원</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{product.category}</td>
-                <td className="px-6 py-4 text-sm text-gray-500 overflow-hidden text-ellipsis">{product.description}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm items-center">
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-800">{product.price.toLocaleString()}원</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{product.category}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-center">
                   <ToggleSwitch
                     isOn={!product.isSoldOut}
                     handleToggle={() => handleToggleSoldOut(product.id)}
                     onColor="bg-green-500"
                     offColor="bg-red-500"
                   />
-                  <span className="ml-2 text-gray-700 font-medium align-middle">
+                  <span className={`ml-2 text-sm font-medium ${product.isSoldOut ? 'text-red-600' : 'text-green-600'}`}>
                     {product.isSoldOut ? "품절" : "판매중"}
                   </span>
                 </td>
-                <td className="px-6 py-4 flex justify-between items-center">
-                  <Button
-                    onClick={() => handleEditProduct(product.id)}
-                    icon={PencilIcon}
-                    fontColor="text-white"
-                    bgColor="bg-blue-500"
-                    hoverColor="hover:bg-blue-600"
-                  />
-                  <Button
-                    onClick={() => handleDeleteProduct(product.id)}
-                    icon={TrashIcon}
-                    fontColor="text-white"
-                    bgColor="bg-red-500"
-                    hoverColor="hover:bg-red-600"
-                  />
+                <td className="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
+                  <div className="flex justify-center items-center gap-4">
+                    <Button
+                      onClick={() => handleEditProduct(product.id)}
+                      icon={PencilIcon}
+                      fontColor="text-white"
+                      bgColor="bg-gray-400"
+                      hoverColor="hover:bg-gray-500"
+                      className="p-2 rounded-full"
+                    />
+                    <Button
+                      onClick={() => handleDeleteProduct(product.id)}
+                      icon={TrashIcon}
+                      fontColor="text-white"
+                      bgColor="bg-red-500"
+                      hoverColor="hover:bg-red-600"
+                      className="p-2 rounded-full"
+                    />
+                  </div>
                 </td>
               </tr>
             ))}

--- a/src/components/features/home/ProductCard.tsx
+++ b/src/components/features/home/ProductCard.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Button from "@/src/components/common/Button";
 import { Product } from "./types";
+import { useUser } from "./context/UserContext";
 
 interface ProductCardProps {
     product: Product;
@@ -11,6 +13,8 @@ interface ProductCardProps {
 
 const ProductCard = ({ product, addToCart }: ProductCardProps) => {
     const [quantity, setQuantity] = useState(0);
+    const { isAuthenticated } = useUser();
+    const router = useRouter();
 
     const isSoldOut = product.isSoldOut;
 
@@ -27,19 +31,25 @@ const ProductCard = ({ product, addToCart }: ProductCardProps) => {
     };
 
     const handleAddToCart = () => {
-        if (isSoldOut) return; // 품절 시 장바구니 담기 방지
+        if (isSoldOut) return;
+
+        if (!isAuthenticated) {
+            alert("로그인이 필요한 서비스입니다.");
+            router.push("/member/login");
+            return;
+        }
 
         const quantityToAdd = quantity === 0 ? 1 : quantity;
         addToCart(product, quantityToAdd);
-        setQuantity(0); // Reset quantity after adding to cart
+        setQuantity(0);
     };
 
     return (
         <div className={`group relative flex h-full w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-all duration-300 hover:shadow-lg`}>
             <div className="aspect-w-3 aspect-h-4 overflow-hidden rounded-t-lg bg-gray-200 relative">
-                <img 
-                    src={product.image} 
-                    alt={product.name} 
+                <img
+                    src={product.image}
+                    alt={product.name}
                     className={`h-full w-full object-cover object-center transition-all duration-300 group-hover:scale-105 ${isSoldOut ? 'grayscale' : ''}`}
                 />
                 {isSoldOut && (
@@ -60,7 +70,7 @@ const ProductCard = ({ product, addToCart }: ProductCardProps) => {
                 <div className="flex flex-col justify-end pt-4">
                     <div className="flex items-center justify-between">
                         <div className="flex items-center rounded-md border border-gray-300">
-                            <button 
+                            <button
                                 onClick={handleDecrease}
                                 className={`px-3 py-1 text-gray-600 transition hover:bg-gray-100 rounded-l-md ${isSoldOut ? 'cursor-not-allowed' : 'cursor-pointer'}`}
                                 disabled={isSoldOut}
@@ -70,7 +80,7 @@ const ProductCard = ({ product, addToCart }: ProductCardProps) => {
                             <span className="px-4 py-1 text-sm font-medium text-gray-800">
                                 {quantity}
                             </span>
-                            <button 
+                            <button
                                 onClick={handleIncrease}
                                 className={`px-3 py-1 text-gray-600 transition hover:bg-gray-100 rounded-r-md ${isSoldOut ? 'cursor-not-allowed' : 'cursor-pointer'}`}
                                 disabled={isSoldOut}
@@ -78,7 +88,7 @@ const ProductCard = ({ product, addToCart }: ProductCardProps) => {
                                 +
                             </button>
                         </div>
-                        <Button 
+                        <Button
                             text="+ 담기"
                             bgColor={isSoldOut ? "bg-gray-400" : "bg-black"}
                             fontColor="text-white"

--- a/src/components/features/home/data/products.ts
+++ b/src/components/features/home/data/products.ts
@@ -52,7 +52,7 @@ export const PRODUCTS: Product[] = [
         price: 5000,
         image: "https://img.danawa.com/prod_img/500000/786/430/img/61430786_1.jpg?_v=20250125114622",
         description: "달콤한 카라멜과 에스프레소의 조화로운 음료",
-        category: "커피",
+        category: "햄스터",
         isSoldOut: false,
     },
 ];

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -62,7 +62,7 @@ const Header = () => {
                 <div className="flex items-center space-x-4">
                   {/* 관리자 계정이면 관리자 페이지 버튼 */}
                   {user?.isAdmin && (
-                    <Button icon={Shield} text="관리자 페이지" />
+                    <Button icon={Shield} text="관리자 페이지" onClick={() => router.push("/admin")} />
                   )}
 
                   {/* 마이페이지 이동 */}


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 메뉴 관리 페이지가 추가되었습니다.
  * 메뉴 추가/수정 모달, 토글 스위치, 연필 및 휴지통 아이콘 등 공통 UI 컴포넌트가 새롭게 도입되었습니다.

* **기능 개선**
  * 상품 카드에서 장바구니 담기 시 로그인 여부를 확인하며, 미인증 사용자는 로그인 페이지로 안내됩니다.
  * 헤더의 "관리자 페이지" 버튼 클릭 시 관리자 페이지로 이동합니다.

* **버그 수정**
  * 메뉴 데이터 중 일부 상품의 카테고리가 수정되었습니다.

* **스타일**
  * 일부 레이아웃 및 JSX 코드의 들여쓰기가 개선되었습니다.

* **기타**
  * 버튼 컴포넌트의 텍스트 prop이 선택사항으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->